### PR TITLE
fix: replace stroke rendering mechanism

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,18 +62,29 @@ function fontCustomUpdate(event) {
     // $("#example").css("font-family", "'"+$fontCustom.val()+"';")
 }
 
+function textStrokeViaShadow(thickness, color = 'black') {
+    const shadowLayers = [];
+
+    for (let angle = 0; angle < 2 * Math.PI; angle += 1 / thickness) {
+        const x = parseFloat((Math.cos(angle) * thickness).toFixed(5));
+        const y = parseFloat((Math.sin(angle) * thickness).toFixed(5));
+        shadowLayers.push(`${x}px ${y}px ${color}`);
+    }
+
+    return shadowLayers.join(', ');
+}
+
 function strokeUpdate(event) {
-    $('link[class="stroke"]').remove();
+    $('link[class="stroke"], style[class="stroke"]').remove();
 
     if ($stroke.val() === "0") return // if "off is selected"
 
-    const stroke = FuckingSettings.strokes[Number($stroke.val()) - 1]
+    const thickness = Number($stroke.val());
 
-    $("<link/>", {
-        rel: "stylesheet",
+    $("<style/>", {
         type: "text/css",
         class: "stroke",
-        href: `styles/stroke_${stroke}.css`
+        text: `#example { text-shadow: ${textStrokeViaShadow(thickness)}; }`
     }).appendTo("head");
 }
 
@@ -339,4 +350,3 @@ $brightness.click(changePreview);
 $url.click(copyUrl);
 $alert.click(showUrl);
 $reset.click(resetForm);
-

--- a/styles/style.css
+++ b/styles/style.css
@@ -278,7 +278,15 @@ input:focus {
 #example .cheer_bits {
     color: rgb(189, 98, 255);
     font-size: 0.6em;
-    -webkit-text-stroke: 1px black;
+    text-shadow:
+        1px 0 black,
+        -1px 0 black,
+        0 1px black,
+        0 -1px black,
+        0.7px 0.7px black,
+        -0.7px 0.7px black,
+        0.7px -0.7px black,
+        -0.7px -0.7px black;
 }
 
 #example .emote {

--- a/v2/script.js
+++ b/v2/script.js
@@ -209,25 +209,25 @@ function textStrokeViaShadow(thickness, color = 'black') {
         return `${x}px ${y}px ${color}`;
     }
 
-    let textShadow = 'text-shadow: ';
+    let textShadow = '';
     for (let angle = 0; angle < 2 * Math.PI; angle += 1/thickness) {
         if (angle !== 0)
             textShadow += ', ';
         textShadow += shadowLayer(Math.cos(angle) * thickness, Math.sin(angle) * thickness, color);
     }
-    textShadow += ';';
 
     return textShadow;
 }
 
+function textStrokeStyle(thickness, color = 'black') {
+    return `text-shadow: ${textStrokeViaShadow(thickness, color)};`;
+}
+
 // See https://github.com/IS2511/ChatIS/issues/16#issuecomment-2745986759
 function applyTextStroke($elem, thickness, color = 'black') {
-    if (obsVersion && obsVersion.major >= 31) {
-        $elem.css('paint-order', 'stroke fill');
-        $elem.css('-webkit-text-stroke', thickness + 'px ' + color);
-    } else {
-        $elem.css('text-shadow', textStrokeViaShadow(thickness, color));
-    }
+    $elem.css('paint-order', '');
+    $elem.css('-webkit-text-stroke', '0px');
+    $elem.css('text-shadow', textStrokeViaShadow(thickness, color));
 }
 
 
@@ -998,11 +998,9 @@ var Chat = {
 
 
     initFlags: function () {
-        // See https://github.com/IS2511/ChatIS/issues/16#issuecomment-2745986759
+        // Native text stroke still breaks some glyph interiors in Chromium/OBS,
+        // so keep the shadow-based outline path enabled consistently.
         Chat.flags.usingHackyStrokeViaShadow = true;
-        if ((obsVersion && obsVersion.major >= 31)) {
-            Chat.flags.usingHackyStrokeViaShadow = false;
-        }
     },
 
     reportLoading: function () {
@@ -1240,10 +1238,7 @@ var Chat = {
                         } break;
                     }
 
-                    let style = `paint-order: stroke fill; -webkit-text-stroke: ${thickness}px black;`;
-                    if (Chat.flags.usingHackyStrokeViaShadow) {
-                        style = textStrokeViaShadow(thickness);
-                    }
+                    let style = textStrokeStyle(thickness);
 
                     $("<style>#chat_container { " + style + " }</style>").appendTo("head");
                 }

--- a/v2/styles/style.css
+++ b/v2/styles/style.css
@@ -28,7 +28,15 @@ body {
 
 .cheer_bits {
     font-size: 0.6em;
-    -webkit-text-stroke: 1px black;
+    text-shadow:
+        1px 0 black,
+        -1px 0 black,
+        0 1px black,
+        0 -1px black,
+        0.7px 0.7px black,
+        -0.7px 0.7px black,
+        0.7px -0.7px black,
+        -0.7px -0.7px black;
 }
 
 .emote {


### PR DESCRIPTION
Recently I've tried adding strokes, but they seems to still be broken, even though the [https://github.com/IS2511/ChatIS/issues/16](ChatIS#16) was closed as completed:
<img width="1004" height="449" alt="image" src="https://github.com/user-attachments/assets/3d7d2261-52f2-4b47-9874-1df1554e4c1e" />

This PR fixes the stroke mechanism by switching stroke rendering to the shadow-based outline path consistently, instead of relying on native -webkit-text-stroke where it produces broken results.
It also updates the preview/generator so stroke rendering matches the actual overlay behavior.